### PR TITLE
feat: deprecate playerAtom and enable multiple player entities

### DIFF
--- a/src/game/systems/KeyboardInputSystem.ts
+++ b/src/game/systems/KeyboardInputSystem.ts
@@ -1,6 +1,6 @@
 import type { System, UpdateArgs } from './Systems';
 import type { Entity } from '../utils/ecsUtils';
-import { getPlayerEntities } from '../utils/EntityUtils';
+import { getEntitiesWithComponent } from '../utils/EntityUtils';
 import {
   getComponentIfExists,
   setComponent,
@@ -28,7 +28,7 @@ export class KeyboardInputSystem implements System {
   update({ entities, map }: UpdateArgs) {
     if (entities.length === 0 || !map || !this.hasChanged) return;
 
-    const playerEntities = getPlayerEntities(entities);
+    const playerEntities = getEntitiesWithComponent(ComponentType.Player, entities);
 
     for (const playerEntity of playerEntities) {
       this.handleMovement(playerEntity);

--- a/src/game/systems/KeyboardInputSystem.ts
+++ b/src/game/systems/KeyboardInputSystem.ts
@@ -1,6 +1,6 @@
 import type { System, UpdateArgs } from './Systems';
 import type { Entity } from '../utils/ecsUtils';
-import { getEntitiesWithComponent } from '../utils/EntityUtils';
+import { getPlayerEntities } from '../utils/EntityUtils';
 import {
   getComponentIfExists,
   setComponent,
@@ -28,16 +28,14 @@ export class KeyboardInputSystem implements System {
   update({ entities, map }: UpdateArgs) {
     if (entities.length === 0 || !map || !this.hasChanged) return;
 
-    const playerEntities = getEntitiesWithComponent(
-      ComponentType.Player,
-      entities,
-    );
-    if (playerEntities.length !== 1) return;
-    const playerEntity = playerEntities[0];
+    const playerEntities = getPlayerEntities(entities);
 
-    this.handleMovement(playerEntity);
-    this.handleInteraction(playerEntity);
-    this.handlePickup(playerEntity);
+    for (const playerEntity of playerEntities) {
+      this.handleMovement(playerEntity);
+      this.handleInteraction(playerEntity);
+      this.handlePickup(playerEntity);
+    }
+
     this.hasChanged = false;
   }
 

--- a/src/game/systems/PickupSystem.ts
+++ b/src/game/systems/PickupSystem.ts
@@ -11,52 +11,53 @@ import {
   setComponent,
 } from '../components/ComponentOperations';
 import type { System, UpdateArgs } from './Systems';
-import { getEntitiesAtPosition, getPlayerEntity } from '../utils/EntityUtils';
+import { getEntitiesAtPosition, getPlayerEntities } from '../utils/EntityUtils';
 
 export class PickupSystem implements System {
   update({ entities }: UpdateArgs) {
-    const playerEntity = getPlayerEntity(entities);
-    if (!playerEntity) return;
+    const playerEntities = getPlayerEntities(entities);
 
-    const handlingComponent = getComponentIfExists(
-      playerEntity,
-      ComponentType.Handling,
-    );
-    const positionComponent = getComponentIfExists(
-      playerEntity,
-      ComponentType.Position,
-    );
-    if (!positionComponent || !handlingComponent) return;
-
-    const carriedItemComponent = getComponentIfExists(
-      playerEntity,
-      ComponentType.CarriedItem,
-    );
-    if (carriedItemComponent) {
-      // Place an item
-      const itemEntity = entities.find(
-        (entity) => entity.id === carriedItemComponent.item,
+    for (const playerEntity of playerEntities) {
+      const handlingComponent = getComponentIfExists(
+        playerEntity,
+        ComponentType.Handling,
       );
-      if (itemEntity) {
-        setComponent(itemEntity, new PositionComponent(positionComponent));
-        removeComponent(playerEntity, ComponentType.CarriedItem);
-      }
-    } else {
-      // Pick up an item
-      const itemsAtPosition = getEntitiesAtPosition(positionComponent).filter(
-        (entity) => hasComponent(entity, ComponentType.Pickable),
+      const positionComponent = getComponentIfExists(
+        playerEntity,
+        ComponentType.Position,
       );
+      if (!positionComponent || !handlingComponent) continue;
 
-      if (itemsAtPosition.length > 0) {
-        const firstItem = itemsAtPosition[0];
-        const newCarriedItemComponent = new CarriedItemComponent({
-          item: firstItem.id,
-        });
-        removeMapComponents(firstItem);
-        setComponent(playerEntity, newCarriedItemComponent);
+      const carriedItemComponent = getComponentIfExists(
+        playerEntity,
+        ComponentType.CarriedItem,
+      );
+      if (carriedItemComponent) {
+        // Place an item
+        const itemEntity = entities.find(
+          (entity) => entity.id === carriedItemComponent.item,
+        );
+        if (itemEntity) {
+          setComponent(itemEntity, new PositionComponent(positionComponent));
+          removeComponent(playerEntity, ComponentType.CarriedItem);
+        }
+      } else {
+        // Pick up an item
+        const itemsAtPosition = getEntitiesAtPosition(positionComponent).filter(
+          (entity) => hasComponent(entity, ComponentType.Pickable),
+        );
+
+        if (itemsAtPosition.length > 0) {
+          const firstItem = itemsAtPosition[0];
+          const newCarriedItemComponent = new CarriedItemComponent({
+            item: firstItem.id,
+          });
+          removeMapComponents(firstItem);
+          setComponent(playerEntity, newCarriedItemComponent);
+        }
       }
+
+      removeComponent(playerEntity, ComponentType.Handling);
     }
-
-    removeComponent(playerEntity, ComponentType.Handling);
   }
 }

--- a/src/game/systems/PickupSystem.ts
+++ b/src/game/systems/PickupSystem.ts
@@ -11,11 +11,11 @@ import {
   setComponent,
 } from '../components/ComponentOperations';
 import type { System, UpdateArgs } from './Systems';
-import { getEntitiesAtPosition, getPlayerEntities } from '../utils/EntityUtils';
+import { getEntitiesAtPosition, getEntitiesWithComponent } from '../utils/EntityUtils';
 
 export class PickupSystem implements System {
   update({ entities }: UpdateArgs) {
-    const playerEntities = getPlayerEntities(entities);
+    const playerEntities = getEntitiesWithComponent(ComponentType.Player, entities);
 
     for (const playerEntity of playerEntities) {
       const handlingComponent = getComponentIfExists(

--- a/src/game/utils/Atoms.ts
+++ b/src/game/utils/Atoms.ts
@@ -1,8 +1,6 @@
 import type { Container, Spritesheet } from 'pixi.js';
 import { atom, createStore } from 'jotai';
 import { GameMap } from '../map/GameMap';
-import { ComponentType } from '../components';
-import { hasComponent } from '../components/ComponentOperations';
 import type { System } from '../systems/Systems';
 import type { Entity } from './ecsUtils';
 
@@ -143,7 +141,3 @@ export const getTileSizeAtom = atom((get) => {
 export const entitiesAtom = atom<Entity[]>([]);
 export const systemsAtom = atom<System[]>([]);
 export const mapAtom = atom<GameMap>(new GameMap());
-export const playerAtom = atom((get) => {
-  const entities = get(entitiesAtom);
-  return entities.find((entity) => hasComponent(entity, ComponentType.Player));
-});

--- a/src/game/utils/EntityUtils.ts
+++ b/src/game/utils/EntityUtils.ts
@@ -56,8 +56,12 @@ export const getEntitiesWithComponents = (
   return entities.filter((entity) => hasAllComponents(entity, ...types));
 };
 
+export const getPlayerEntities = (entities?: Entity[]): Entity[] => {
+  return getEntitiesWithComponent(ComponentType.Player, entities);
+};
+
 export const getPlayerEntity = (entities?: Entity[]): Entity | undefined => {
-  const players = getEntitiesWithComponent(ComponentType.Player, entities);
+  const players = getPlayerEntities(entities);
   return players.length === 1 ? players[0] : undefined;
 };
 

--- a/src/game/utils/EntityUtils.ts
+++ b/src/game/utils/EntityUtils.ts
@@ -56,14 +56,6 @@ export const getEntitiesWithComponents = (
   return entities.filter((entity) => hasAllComponents(entity, ...types));
 };
 
-export const getPlayerEntities = (entities?: Entity[]): Entity[] => {
-  return getEntitiesWithComponent(ComponentType.Player, entities);
-};
-
-export const getPlayerEntity = (entities?: Entity[]): Entity | undefined => {
-  const players = getPlayerEntities(entities);
-  return players.length === 1 ? players[0] : undefined;
-};
 
 export const addEntity = (entity: Entity) => {
   store.set(entitiesAtom, (entities) => [...entities, entity]);

--- a/tests/integration/ItemUsage.integration.test.ts
+++ b/tests/integration/ItemUsage.integration.test.ts
@@ -22,12 +22,17 @@ import { ItemInteractionSystem } from '../../src/game/systems/ItemInteractionSys
 import {
   getEntitiesAtPosition,
   getEntity,
-  getPlayerEntity,
+  getEntitiesWithComponent,
 } from '../../src/game/utils/EntityUtils';
 import { entitiesAtom, mapAtom, store } from '../../src/game/utils/Atoms';
 import { GameMap } from '../../src/game/map/GameMap';
 
 describe('Item Usage Integration Test', () => {
+  // Helper function to get player entity for tests
+  const getPlayerEntity = () => {
+    const players = getEntitiesWithComponent(ComponentType.Player);
+    return players.length === 1 ? players[0] : undefined;
+  };
   describe('Full workflow: move to key → pickup key → move to chest → use key → chest opens', () => {
     const originalKey = createEntity(
       ConvenienceComponentSets.key({ x: 1, y: 1 }, 'unlock'),

--- a/tests/integration/Movement.integration.test.ts
+++ b/tests/integration/Movement.integration.test.ts
@@ -24,11 +24,6 @@ import { entitiesAtom, mapAtom, store } from '../../src/game/utils/Atoms';
 import { GameMap } from '../../src/game/map/GameMap';
 
 describe('Movement Integration Test', () => {
-  // Helper function to get player entity for tests
-  const getPlayerEntity = () => {
-    const players = getEntitiesWithComponent(ComponentType.Player);
-    return players.length === 1 ? players[0] : undefined;
-  };
   describe('when player moves in open space', () => {
     const originalPlayer = createEntity(
       ConvenienceComponentSets.player({ x: 5, y: 5 }),
@@ -40,64 +35,85 @@ describe('Movement Integration Test', () => {
       store.set(entitiesAtom, [originalPlayer]);
       store.set(mapAtom, new GameMap());
 
-      const player = getPlayerEntity();
-      expect(player).toBeDefined();
-      const position = getComponentAbsolute(player!, ComponentType.Position);
+      const players = getEntitiesWithComponent(ComponentType.Player);
+      expect(players.length).toBe(1);
+      const player = players[0];
+      const position = getComponentAbsolute(player, ComponentType.Position);
       expect(position.x).toBe(5);
       expect(position.y).toBe(5);
     });
 
     it('should move player right', () => {
-      let player = getPlayerEntity();
-      setComponent(player!, new VelocityComponent({ vx: 1, vy: 0 }));
+      const players = getEntitiesWithComponent(ComponentType.Player);
+      expect(players.length).toBe(1);
+      let player = players[0];
+      setComponent(player, new VelocityComponent({ vx: 1, vy: 0 }));
       movementSystem.update(createStandardUpdateArgs());
 
-      player = getPlayerEntity();
-      const position = getComponentAbsolute(player!, ComponentType.Position);
+      const playersAfterMove = getEntitiesWithComponent(ComponentType.Player);
+      expect(playersAfterMove.length).toBe(1);
+      player = playersAfterMove[0];
+      const position = getComponentAbsolute(player, ComponentType.Position);
       expect(position.x).toBe(6);
       expect(position.y).toBe(5);
     });
 
     it('should move player down', () => {
-      let player = getPlayerEntity();
-      setComponent(player!, new VelocityComponent({ vx: 0, vy: 1 }));
+      const players = getEntitiesWithComponent(ComponentType.Player);
+      expect(players.length).toBe(1);
+      let player = players[0];
+      setComponent(player, new VelocityComponent({ vx: 0, vy: 1 }));
       movementSystem.update(createStandardUpdateArgs());
 
-      player = getPlayerEntity();
-      const position = getComponentAbsolute(player!, ComponentType.Position);
+      const playersAfterMove = getEntitiesWithComponent(ComponentType.Player);
+      expect(playersAfterMove.length).toBe(1);
+      player = playersAfterMove[0];
+      const position = getComponentAbsolute(player, ComponentType.Position);
       expect(position.x).toBe(6);
       expect(position.y).toBe(6);
     });
 
     it('should move player left', () => {
-      let player = getPlayerEntity();
-      setComponent(player!, new VelocityComponent({ vx: -1, vy: 0 }));
+      const players = getEntitiesWithComponent(ComponentType.Player);
+      expect(players.length).toBe(1);
+      let player = players[0];
+      setComponent(player, new VelocityComponent({ vx: -1, vy: 0 }));
       movementSystem.update(createStandardUpdateArgs());
 
-      player = getPlayerEntity();
-      const position = getComponentAbsolute(player!, ComponentType.Position);
+      const playersAfterMove = getEntitiesWithComponent(ComponentType.Player);
+      expect(playersAfterMove.length).toBe(1);
+      player = playersAfterMove[0];
+      const position = getComponentAbsolute(player, ComponentType.Position);
       expect(position.x).toBe(5);
       expect(position.y).toBe(6);
     });
 
     it('should move player up', () => {
-      let player = getPlayerEntity();
-      setComponent(player!, new VelocityComponent({ vx: 0, vy: -1 }));
+      const players = getEntitiesWithComponent(ComponentType.Player);
+      expect(players.length).toBe(1);
+      let player = players[0];
+      setComponent(player, new VelocityComponent({ vx: 0, vy: -1 }));
       movementSystem.update(createStandardUpdateArgs());
 
-      player = getPlayerEntity();
-      const position = getComponentAbsolute(player!, ComponentType.Position);
+      const playersAfterMove = getEntitiesWithComponent(ComponentType.Player);
+      expect(playersAfterMove.length).toBe(1);
+      player = playersAfterMove[0];
+      const position = getComponentAbsolute(player, ComponentType.Position);
       expect(position.x).toBe(5);
       expect(position.y).toBe(5);
     });
 
     it('should reset velocity after movement', () => {
-      let player = getPlayerEntity();
-      setComponent(player!, new VelocityComponent({ vx: 1, vy: 1 }));
+      const players = getEntitiesWithComponent(ComponentType.Player);
+      expect(players.length).toBe(1);
+      let player = players[0];
+      setComponent(player, new VelocityComponent({ vx: 1, vy: 1 }));
       movementSystem.update(createStandardUpdateArgs());
 
-      player = getPlayerEntity();
-      const velocity = getComponentAbsolute(player!, ComponentType.Velocity);
+      const playersAfterMove = getEntitiesWithComponent(ComponentType.Player);
+      expect(playersAfterMove.length).toBe(1);
+      player = playersAfterMove[0];
+      const velocity = getComponentAbsolute(player, ComponentType.Velocity);
       expect(velocity.vx).toBe(0);
       expect(velocity.vy).toBe(0);
     });
@@ -119,20 +135,24 @@ describe('Movement Integration Test', () => {
         store.set(entitiesAtom, [player, wall]);
         store.set(mapAtom, new GameMap());
 
-        let currentPlayer = getPlayerEntity();
-        setComponent(currentPlayer!, new VelocityComponent({ vx: 1, vy: 0 }));
+        const players = getEntitiesWithComponent(ComponentType.Player);
+        expect(players.length).toBe(1);
+        let currentPlayer = players[0];
+        setComponent(currentPlayer, new VelocityComponent({ vx: 1, vy: 0 }));
         movementSystem.update(createStandardUpdateArgs());
 
-        currentPlayer = getPlayerEntity();
+        const playersAfterMove = getEntitiesWithComponent(ComponentType.Player);
+        expect(playersAfterMove.length).toBe(1);
+        currentPlayer = playersAfterMove[0];
         const position = getComponentAbsolute(
-          currentPlayer!,
+          currentPlayer,
           ComponentType.Position,
         );
         expect(position.x).toBe(2);
         expect(position.y).toBe(2);
 
         const velocity = getComponentAbsolute(
-          currentPlayer!,
+          currentPlayer,
           ComponentType.Velocity,
         );
         expect(velocity.vx).toBe(0);
@@ -151,29 +171,35 @@ describe('Movement Integration Test', () => {
         store.set(entitiesAtom, [player]);
         store.set(mapAtom, new GameMap());
 
-        let currentPlayer = getPlayerEntity();
+        const players = getEntitiesWithComponent(ComponentType.Player);
+        expect(players.length).toBe(1);
+        let currentPlayer = players[0];
 
-        setComponent(currentPlayer!, new VelocityComponent({ vx: -1, vy: 0 }));
+        setComponent(currentPlayer, new VelocityComponent({ vx: -1, vy: 0 }));
         movementSystem.update(createStandardUpdateArgs());
 
-        currentPlayer = getPlayerEntity();
+        const playersAfterFirstMove = getEntitiesWithComponent(ComponentType.Player);
+        expect(playersAfterFirstMove.length).toBe(1);
+        currentPlayer = playersAfterFirstMove[0];
         let position = getComponentAbsolute(
-          currentPlayer!,
+          currentPlayer,
           ComponentType.Position,
         );
         expect(position.x).toBe(0);
         expect(position.y).toBe(0);
 
-        setComponent(currentPlayer!, new VelocityComponent({ vx: 0, vy: -1 }));
+        setComponent(currentPlayer, new VelocityComponent({ vx: 0, vy: -1 }));
         movementSystem.update(createStandardUpdateArgs());
 
-        currentPlayer = getPlayerEntity();
-        position = getComponentAbsolute(currentPlayer!, ComponentType.Position);
+        const playersAfterSecondMove = getEntitiesWithComponent(ComponentType.Player);
+        expect(playersAfterSecondMove.length).toBe(1);
+        currentPlayer = playersAfterSecondMove[0];
+        position = getComponentAbsolute(currentPlayer, ComponentType.Position);
         expect(position.x).toBe(0);
         expect(position.y).toBe(0);
 
         const velocity = getComponentAbsolute(
-          currentPlayer!,
+          currentPlayer,
           ComponentType.Velocity,
         );
         expect(velocity.vx).toBe(0);
@@ -201,13 +227,17 @@ describe('Movement Integration Test', () => {
       store.set(entitiesAtom, [player, pickableItem, walkableFloor]);
       store.set(mapAtom, new GameMap());
 
-      let currentPlayer = getPlayerEntity();
-      setComponent(currentPlayer!, new VelocityComponent({ vx: 1, vy: 0 }));
+      const players = getEntitiesWithComponent(ComponentType.Player);
+      expect(players.length).toBe(1);
+      let currentPlayer = players[0];
+      setComponent(currentPlayer, new VelocityComponent({ vx: 1, vy: 0 }));
       movementSystem.update(createStandardUpdateArgs());
 
-      currentPlayer = getPlayerEntity();
+      const playersAfterMove = getEntitiesWithComponent(ComponentType.Player);
+      expect(playersAfterMove.length).toBe(1);
+      currentPlayer = playersAfterMove[0];
       const position = getComponentAbsolute(
-        currentPlayer!,
+        currentPlayer,
         ComponentType.Position,
       );
       expect(position.x).toBe(3);
@@ -218,14 +248,18 @@ describe('Movement Integration Test', () => {
     });
 
     it('should allow movement onto walkable entities', () => {
-      let currentPlayer = getPlayerEntity();
+      const players = getEntitiesWithComponent(ComponentType.Player);
+      expect(players.length).toBe(1);
+      let currentPlayer = players[0];
 
-      setComponent(currentPlayer!, new VelocityComponent({ vx: 1, vy: 0 }));
+      setComponent(currentPlayer, new VelocityComponent({ vx: 1, vy: 0 }));
       movementSystem.update(createStandardUpdateArgs());
 
-      currentPlayer = getPlayerEntity();
+      const playersAfterMove = getEntitiesWithComponent(ComponentType.Player);
+      expect(playersAfterMove.length).toBe(1);
+      currentPlayer = playersAfterMove[0];
       const position = getComponentAbsolute(
-        currentPlayer!,
+        currentPlayer,
         ComponentType.Position,
       );
       expect(position.x).toBe(4);
@@ -253,13 +287,17 @@ describe('Movement Integration Test', () => {
         store.set(entitiesAtom, [player, movableBox]);
         store.set(mapAtom, new GameMap());
 
-        let currentPlayer = getPlayerEntity();
-        setComponent(currentPlayer!, new VelocityComponent({ vx: 1, vy: 0 }));
+        const players = getEntitiesWithComponent(ComponentType.Player);
+        expect(players.length).toBe(1);
+        let currentPlayer = players[0];
+        setComponent(currentPlayer, new VelocityComponent({ vx: 1, vy: 0 }));
         movementSystem.update(createStandardUpdateArgs());
 
-        currentPlayer = getPlayerEntity();
+        const playersAfterMove = getEntitiesWithComponent(ComponentType.Player);
+        expect(playersAfterMove.length).toBe(1);
+        currentPlayer = playersAfterMove[0];
         const playerPosition = getComponentAbsolute(
-          currentPlayer!,
+          currentPlayer,
           ComponentType.Position,
         );
         expect(playerPosition.x).toBe(3);
@@ -291,18 +329,22 @@ describe('Movement Integration Test', () => {
         store.set(entitiesAtom, [player, movableBox, blockingWall]);
         store.set(mapAtom, new GameMap());
 
-        let currentPlayer = getPlayerEntity();
+        const players = getEntitiesWithComponent(ComponentType.Player);
+        expect(players.length).toBe(1);
+        let currentPlayer = players[0];
         const originalPosition = getComponentAbsolute(
-          currentPlayer!,
+          currentPlayer,
           ComponentType.Position,
         );
 
-        setComponent(currentPlayer!, new VelocityComponent({ vx: 1, vy: 0 }));
+        setComponent(currentPlayer, new VelocityComponent({ vx: 1, vy: 0 }));
         movementSystem.update(createStandardUpdateArgs());
 
-        currentPlayer = getPlayerEntity();
+        const playersAfterMove = getEntitiesWithComponent(ComponentType.Player);
+        expect(playersAfterMove.length).toBe(1);
+        currentPlayer = playersAfterMove[0];
         const finalPosition = getComponentAbsolute(
-          currentPlayer!,
+          currentPlayer,
           ComponentType.Position,
         );
         expect(finalPosition.x).toBe(originalPosition.x);
@@ -314,7 +356,7 @@ describe('Movement Integration Test', () => {
         );
 
         const velocity = getComponentAbsolute(
-          currentPlayer!,
+          currentPlayer,
           ComponentType.Velocity,
         );
         expect(velocity.vx).toBe(0);
@@ -343,13 +385,17 @@ describe('Movement Integration Test', () => {
         store.set(entitiesAtom, [player, movableBox1, movableBox2]);
         store.set(mapAtom, new GameMap());
 
-        let currentPlayer = getPlayerEntity();
-        setComponent(currentPlayer!, new VelocityComponent({ vx: 1, vy: 0 }));
+        const players = getEntitiesWithComponent(ComponentType.Player);
+        expect(players.length).toBe(1);
+        let currentPlayer = players[0];
+        setComponent(currentPlayer, new VelocityComponent({ vx: 1, vy: 0 }));
         movementSystem.update(createStandardUpdateArgs());
 
-        currentPlayer = getPlayerEntity();
+        const playersAfterMove = getEntitiesWithComponent(ComponentType.Player);
+        expect(playersAfterMove.length).toBe(1);
+        currentPlayer = playersAfterMove[0];
         const playerPosition = getComponentAbsolute(
-          currentPlayer!,
+          currentPlayer,
           ComponentType.Position,
         );
         expect(playerPosition.x).toBe(5);
@@ -364,6 +410,52 @@ describe('Movement Integration Test', () => {
         expect(
           entitiesAtBox2Position.some((e) => e.id === movableBox2.id),
         ).toBe(true);
+      });
+    });
+  });
+
+  describe('Multiple players scenario', () => {
+    it('should handle multiple players moving independently', () => {
+      const player1 = createEntity(
+        ConvenienceComponentSets.player({ x: 0, y: 0 }),
+      );
+      const player2 = createEntity(
+        ConvenienceComponentSets.player({ x: 3, y: 3 }),
+      );
+
+      const movementSystem = new MovementSystem();
+
+      // Initialize with multiple players
+      store.set(entitiesAtom, [player1, player2]);
+      store.set(mapAtom, new GameMap());
+
+      // Verify we have 2 players
+      const players = getEntitiesWithComponent(ComponentType.Player);
+      expect(players.length).toBe(2);
+
+      // Set different velocities for each player
+      setComponent(players[0], new VelocityComponent({ vx: 1, vy: 1 }));
+      setComponent(players[1], new VelocityComponent({ vx: -1, vy: -1 }));
+      movementSystem.update(createStandardUpdateArgs());
+
+      // Both players should have moved independently
+      const playersAfterMove = getEntitiesWithComponent(ComponentType.Player);
+      expect(playersAfterMove.length).toBe(2);
+
+      const positions = playersAfterMove.map(player => {
+        const pos = getComponentAbsolute(player, ComponentType.Position);
+        return { x: pos.x, y: pos.y };
+      });
+
+      // Players should have moved to their new positions
+      expect(positions).toContainEqual({ x: 1, y: 1 });
+      expect(positions).toContainEqual({ x: 2, y: 2 });
+
+      // Both players' velocities should be reset
+      playersAfterMove.forEach(player => {
+        const velocity = getComponentAbsolute(player, ComponentType.Velocity);
+        expect(velocity.vx).toBe(0);
+        expect(velocity.vy).toBe(0);
       });
     });
   });

--- a/tests/integration/Movement.integration.test.ts
+++ b/tests/integration/Movement.integration.test.ts
@@ -18,12 +18,17 @@ import { createEntity } from '../../src/game/utils/EntityFactory';
 import { MovementSystem } from '../../src/game/systems/MovementSystem';
 import {
   getEntitiesAtPosition,
-  getPlayerEntity,
+  getEntitiesWithComponent,
 } from '../../src/game/utils/EntityUtils';
 import { entitiesAtom, mapAtom, store } from '../../src/game/utils/Atoms';
 import { GameMap } from '../../src/game/map/GameMap';
 
 describe('Movement Integration Test', () => {
+  // Helper function to get player entity for tests
+  const getPlayerEntity = () => {
+    const players = getEntitiesWithComponent(ComponentType.Player);
+    return players.length === 1 ? players[0] : undefined;
+  };
   describe('when player moves in open space', () => {
     const originalPlayer = createEntity(
       ConvenienceComponentSets.player({ x: 5, y: 5 }),


### PR DESCRIPTION
This PR addresses issue #53 by deprecating the get player atom and making the game more ECS-compliant.

## Changes
- Removed playerAtom from Atoms.ts
- Updated KeyboardInputSystem to handle multiple players
- Updated PickupSystem to handle multiple players
- Added getPlayerEntities() function for better ECS compliance

The game now properly supports multiple entities with Player component instead of assuming a single player.

🤖 Generated with [Claude Code](https://claude.ai/code)