### PR TITLE
[WIP] Implement tile hover highlighting system for level editor

### DIFF
--- a/src/game/components/ComponentTypes.ts
+++ b/src/game/components/ComponentTypes.ts
@@ -45,6 +45,7 @@ import type {
   RenderComponentProps,
 } from './individualComponents/RenderComponent';
 import type { SelectedComponent } from './individualComponents/SelectedComponent';
+import type { HoverHighlightComponent } from './individualComponents/HoverHighlightComponent';
 
 export enum ComponentType {
   Position = 'position',
@@ -64,6 +65,7 @@ export enum ComponentType {
   InteractionBehavior = 'interactionBehavior',
   SpawnContents = 'spawnContents',
   Selected = 'selected',
+  HoverHighlight = 'hoverHighlight',
 }
 
 export type FullComponentDictionary = {
@@ -84,6 +86,7 @@ export type FullComponentDictionary = {
   [ComponentType.InteractionBehavior]: InteractionBehaviorComponent;
   [ComponentType.SpawnContents]: SpawnContentsComponent;
   [ComponentType.Selected]: SelectedComponent;
+  [ComponentType.HoverHighlight]: HoverHighlightComponent;
 };
 
 export type Component = FullComponentDictionary[keyof FullComponentDictionary];

--- a/src/game/components/index.ts
+++ b/src/game/components/index.ts
@@ -2,6 +2,7 @@ export * from './ComponentTypes';
 export * from './individualComponents/CarriedItemComponent';
 export * from './individualComponents/DirectionComponent';
 export * from './individualComponents/HandlingComponent';
+export * from './individualComponents/HoverHighlightComponent';
 export * from './individualComponents/InteractingComponent';
 export * from './individualComponents/InteractionBehaviorComponent';
 export * from './individualComponents/MovableComponent';

--- a/src/game/components/individualComponents/HoverHighlightComponent.ts
+++ b/src/game/components/individualComponents/HoverHighlightComponent.ts
@@ -1,0 +1,10 @@
+import { ComponentType } from '../ComponentTypes';
+
+export class HoverHighlightComponent {
+  type = ComponentType.HoverHighlight;
+  isVisible: boolean;
+
+  constructor({ isVisible }: { isVisible: boolean }) {
+    this.isVisible = isVisible;
+  }
+}

--- a/src/game/config/SystemConfigurations.ts
+++ b/src/game/config/SystemConfigurations.ts
@@ -10,6 +10,8 @@ import { SidebarRenderSystem } from '../systems/RenderSystems/SidebarRenderSyste
 import { MapRenderSystem } from '../systems/RenderSystems/MapRenderSystem';
 import { LevelEditorSelectionSystem } from '../systems/LevelEditorSystems/LevelEditorSelectionSystem';
 import { LevelEditorPlacementSystem } from '../systems/LevelEditorSystems/LevelEditorPlacementSystem';
+import { LevelEditorHoverSystem } from '../systems/LevelEditorSystems/LevelEditorHoverSystem';
+import { HoverHighlightRenderSystem } from '../systems/RenderSystems/HoverHighlightRenderSystem';
 import { PickupSystem } from '../systems/PickupSystem';
 import { ItemInteractionSystem } from '../systems/ItemInteractionSystem';
 import { createEntity, createEntityFromTemplate } from '../utils/EntityFactory';
@@ -17,6 +19,7 @@ import {
   Beaker,
   Boulder,
   Chest,
+  HoverHighlight,
   Key,
   Player,
 } from '../templates/EntityTemplates';
@@ -67,6 +70,13 @@ const createSidebarEntities = () => {
   return sidebarEntities;
 };
 
+const createEditorEntities = () => {
+  const sidebarEntities = createSidebarEntities();
+  const hoverHighlightEntity = createEntityFromTemplate(HoverHighlight);
+  
+  return [...sidebarEntities, hoverHighlightEntity];
+};
+
 export interface SystemConfig {
   systemsFactory: (() => BaseSystem)[];
   entitiesFactory?: () => Entity[];
@@ -99,12 +109,14 @@ export const editorSystemConfig: SystemConfig = {
   systemsFactory: [
     () => new LevelEditorSelectionSystem(),
     () => new LevelEditorPlacementSystem(),
+    () => new LevelEditorHoverSystem(),
     () => new MapRenderSystem(),
     () => new GameRenderSystem(),
+    () => new HoverHighlightRenderSystem(),
     () => new SidebarRenderSystem(),
     () => new CleanUpSystem(),
   ],
-  entitiesFactory: createSidebarEntities,
+  entitiesFactory: createEditorEntities,
   mapConfig: {
     rows: 15,
     cols: 15,

--- a/src/game/systems/LevelEditorSystems/LevelEditorHoverSystem.ts
+++ b/src/game/systems/LevelEditorSystems/LevelEditorHoverSystem.ts
@@ -1,0 +1,112 @@
+import { screenToGrid } from '../../map/MappingUtils';
+import type { UpdateArgs } from '../Framework/Systems';
+import type { Position } from '../../map/GameMap';
+import type { Entity } from '../../utils/ecsUtils';
+import { getComponentIfExists, setComponent } from '../../components/ComponentOperations';
+import { HoverHighlightComponent, PositionComponent } from '../../components';
+import { ComponentType } from '../../components';
+import { getEntitiesWithComponent } from '../../utils/EntityUtils';
+import { BaseClickSystem } from '../Framework/BaseClickSystem';
+import type { FederatedPointerEvent, Point } from 'pixi.js';
+import { mapContainerAtom, store, currentGameModeAtom } from '../../utils/Atoms';
+
+export class LevelEditorHoverSystem extends BaseClickSystem {
+  private currentHoverPosition: Position | null = null;
+
+  constructor() {
+    const mapContainer = store.get(mapContainerAtom);
+    if (!mapContainer) {
+      throw new Error('Map container is not initialized');
+    }
+
+    super(mapContainer);
+    
+    mapContainer.eventMode = 'static';
+    mapContainer.on('pointermove', (event: FederatedPointerEvent) => {
+      this.handleMouseMove(event);
+    });
+    
+    mapContainer.on('pointerleave', () => {
+      this.handleMouseLeave();
+    });
+  }
+
+  handleClick(_event: FederatedPointerEvent, _localPosition: Point) {
+    // This system only handles hover, not clicks
+  }
+
+  private handleMouseMove(event: FederatedPointerEvent) {
+    const gameMode = store.get(currentGameModeAtom);
+    if (gameMode !== 'editor') {
+      return;
+    }
+
+    const mapContainer = store.get(mapContainerAtom);
+    if (!mapContainer) {
+      return;
+    }
+
+    const localPosition = mapContainer.toLocal(event.global);
+    const gridPosition = screenToGrid(localPosition);
+    
+    if (localPosition.x < 0 || localPosition.y < 0) {
+      this.currentHoverPosition = null;
+      return;
+    }
+
+    this.currentHoverPosition = gridPosition;
+  }
+
+  private handleMouseLeave() {
+    this.currentHoverPosition = null;
+  }
+
+  update({ entities }: UpdateArgs) {
+    const gameMode = store.get(currentGameModeAtom);
+    if (gameMode !== 'editor') {
+      this.currentHoverPosition = null;
+    }
+
+    const hoverHighlightEntities = getEntitiesWithComponent(
+      ComponentType.HoverHighlight,
+      entities,
+    );
+
+    if (hoverHighlightEntities.length === 0) {
+      return;
+    }
+
+    if (hoverHighlightEntities.length > 1) {
+      throw new Error(
+        'Multiple hover highlight entities found. Only one should exist.',
+      );
+    }
+
+    const highlightEntity = hoverHighlightEntities[0];
+    const positionComponent = getComponentIfExists(
+      highlightEntity,
+      ComponentType.Position,
+    );
+
+    if (this.currentHoverPosition) {
+      setComponent(highlightEntity, new HoverHighlightComponent({
+        isVisible: true,
+      }));
+
+      if (
+        !positionComponent ||
+        positionComponent.x !== this.currentHoverPosition.x ||
+        positionComponent.y !== this.currentHoverPosition.y
+      ) {
+        setComponent(highlightEntity, new PositionComponent({
+          x: this.currentHoverPosition.x,
+          y: this.currentHoverPosition.y,
+        }));
+      }
+    } else {
+      setComponent(highlightEntity, new HoverHighlightComponent({
+        isVisible: false,
+      }));
+    }
+  }
+}

--- a/src/game/systems/RenderSystems/HoverHighlightRenderSystem.ts
+++ b/src/game/systems/RenderSystems/HoverHighlightRenderSystem.ts
@@ -1,0 +1,91 @@
+import type { UpdateArgs } from '../Framework/Systems';
+import { getComponentIfExists } from '../../components/ComponentOperations';
+import { ComponentType } from '../../components';
+import { BaseRenderSystem } from './BaseRenderSystem';
+import type { Container } from 'pixi.js';
+import { Graphics } from 'pixi.js';
+import type { Entity } from '../../utils/ecsUtils';
+import type { InterfaceConfig } from '../../utils/Atoms';
+import { gridToScreenAsTuple } from '../../map/MappingUtils';
+
+export class HoverHighlightRenderSystem extends BaseRenderSystem {
+  constructor() {
+    super('game');
+  }
+
+  update({ entities }: UpdateArgs) {
+    const hoverEntities = entities.filter((entity) => {
+      const renderComponent = getComponentIfExists(
+        entity,
+        ComponentType.Render,
+      );
+      const hoverComponent = getComponentIfExists(
+        entity,
+        ComponentType.HoverHighlight,
+      );
+
+      return (
+        renderComponent?.section === 'game' &&
+        hoverComponent !== undefined
+      );
+    });
+
+    this.updateHoverHighlightEntities(hoverEntities);
+  }
+
+  private updateHoverHighlightEntities(entities: Entity[]) {
+    for (const entity of entities) {
+      const hoverComponent = getComponentIfExists(
+        entity,
+        ComponentType.HoverHighlight,
+      );
+      const positionComponent = getComponentIfExists(
+        entity,
+        ComponentType.Position,
+      );
+
+      if (!hoverComponent || !positionComponent) {
+        continue;
+      }
+
+      let sprite = this.getExistingSprite(entity.id);
+
+      if (!sprite && hoverComponent.isVisible) {
+        sprite = this.createHighlightSprite();
+        this.addSpriteToStage(entity.id, sprite);
+      }
+
+      if (sprite) {
+        sprite.visible = hoverComponent.isVisible;
+        if (hoverComponent.isVisible) {
+          sprite.position.set(
+            ...gridToScreenAsTuple(positionComponent, this.interfaceConfig),
+          );
+        }
+      }
+    }
+  }
+
+  private createHighlightSprite(): Graphics {
+    const graphics = new Graphics();
+    const tileSize = this.interfaceConfig.tileSize;
+    
+    graphics.lineStyle(2, 0xffffff, 0.8);
+    graphics.beginFill(0xffffff, 0.2);
+    graphics.drawRect(0, 0, tileSize, tileSize);
+    graphics.endFill();
+    
+    return graphics;
+  }
+
+  private getExistingSprite(entityId: string): Container | undefined {
+    return this.stage.children.find(child => 
+      (child as any).__entityId === entityId
+    ) as Container | undefined;
+  }
+
+  private addSpriteToStage(entityId: string, sprite: Container) {
+    (sprite as any).__entityId = entityId;
+    this.stage.addChild(sprite);
+  }
+}

--- a/src/game/templates/EntityTemplates.ts
+++ b/src/game/templates/EntityTemplates.ts
@@ -88,3 +88,11 @@ export const Chest: EntityTemplate = {
     render: { section: 'game' },
   },
 };
+
+export const HoverHighlight: EntityTemplate = {
+  components: {
+    position: { x: 0, y: 0 },
+    hoverHighlight: { isVisible: false },
+    render: { section: 'game' },
+  },
+};

--- a/src/game/utils/EntityFactory.ts
+++ b/src/game/utils/EntityFactory.ts
@@ -17,6 +17,7 @@ import type {
 import {
   CarriedItemComponent,
   ComponentType,
+  HoverHighlightComponent,
   InteractionBehaviorComponent,
   PositionComponent,
   RenderComponent,
@@ -198,6 +199,8 @@ function createComponentsFromTemplate(template: EntityTemplate): Component[] {
         return new SpawnContentsComponent(props as SpawnContentsComponentProps);
       case ComponentType.Render:
         return new RenderComponent(props as RenderComponentProps);
+      case ComponentType.HoverHighlight:
+        return new HoverHighlightComponent(props as { isVisible: boolean });
       default:
         if (Object.values(ComponentType).includes(type as ComponentType)) {
           return { type } as Component;


### PR DESCRIPTION
Closes #68

Implements a tile hover highlighting system for the level editor to show which tile the mouse is hovering over.

## Changes
- Add HoverHighlightComponent for tracking highlight visibility
- Create LevelEditorHoverSystem to track mouse position and convert to grid coordinates
- Add HoverHighlightRenderSystem for rendering semi-transparent highlight overlay
- Integrate systems with editor configuration
- Only shows highlight when in editor mode and mouse is within game area

🤖 Generated with [Claude Code](https://claude.ai/code)